### PR TITLE
Fixed an issue while building the example and test programs using an older version of CMake

### DIFF
--- a/loguru_bench/CMakeLists.txt
+++ b/loguru_bench/CMakeLists.txt
@@ -9,7 +9,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 MESSAGE(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
-add_compile_options(-std=c++11 -Werror -Wall -Wextra)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
 
 file(GLOB source
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/loguru_example/CMakeLists.txt
+++ b/loguru_example/CMakeLists.txt
@@ -9,7 +9,7 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 MESSAGE(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
-add_compile_options(-std=c++11 -Werror -Wall -Wextra)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
 
 file(GLOB source
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,22 +9,21 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 MESSAGE(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
 
-add_compile_options(-std=c++11 -Werror -Wall -Wextra)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
 
-add_compile_options(
-    -Weverything
-    -Wno-c++98-compat
-    -Wno-c++98-compat-pedantic
-    -Wno-disabled-macro-expansion
-    -Wno-exit-time-destructors
-    -Wno-global-constructors
-    -Wno-missing-noreturn
-    -Wno-missing-prototypes
-    -Wno-non-virtual-dtor
-    -Wno-padded
-    -Wno-pedantic
-    -Wno-weak-vtables
-)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat-pedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-disabled-macro-expansion")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-exit-time-destructors")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-global-constructors")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-noreturn")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-prototypes")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-non-virtual-dtor")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-padded")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-weak-vtables")
+
 
 file(GLOB source
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"


### PR DESCRIPTION
When I tried to build the test and the example program of loguru. I had the following error:

    CMake Error at CMakeLists.txt:12 (add_compile_options):
    Unknown CMake command "add_compile_options"

It seems the CMake command *add_compile_option()* is available in CMake 2.8.12 and later, and I have the version 2.8.7. So, in order to allow the users to build the test program and the examples using an older version of CMake, I added a support of that using the *set()* command.

This solution should work on every versions that have the support of this command, including the latest versions of CMake.