### PR TITLE
Support fmtlib formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ In particular, I want logging that produces logs that are both human-readable an
 * Drop-in replacement for most of GLOG (except for setup code).
 * Choose between using printf-style or std::cout-style formatting.
 * Compile-time checked printf-formating (on supported compilers).
+* Support for [fmtlib](https://github.com/fmtlib/fmt) formatting.
+	* Add `#define LOGURU_USE_FMTLIB 1`, before including `loguru.hpp`
+	* You also need to set up the `fmtlib` include directory for building as well as linking against `fmtlib`, alternatively use the `FMT_HEADER_ONLY` preprocessor definition
 * Assertion failures are marked with `noreturn` for the benefit of the static analyzer and optimizer.
 * All logging also written to stderr.
 	* With colors on supported terminals.

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -462,7 +462,7 @@ namespace loguru
 	#if LOGURU_USE_FMTLIB
 	// Actual logging function. Use the LOG macro instead of calling this directly.
 	void log(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, fmt::ArgList args);
-	FMT_VARIADIC(void, log, Verbosity, const char*, unsigned, const char*)
+	FMT_VARIADIC(void, log, Verbosity, const char*, unsigned, LOGURU_FORMAT_STRING_TYPE)
 
 	// Log without any preamble or indentation.
 	void raw_log(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, fmt::ArgList args);

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -128,6 +128,9 @@ Website: www.ilikebigbits.com
 		Make Loguru try to do unsafe but useful things,
 		like printing a stack trace, when catching signals.
 		This may lead to bad things like deadlocks in certain situations.
+	
+	LOGURU_USE_FMTLIB (default 0):
+		Use fmtlib formatting. See https://github.com/fmtlib/fmt
 
 	You can also configure:
 	loguru::g_flush_interval_ms:
@@ -202,6 +205,10 @@ Website: www.ilikebigbits.com
 #if LOGURU_IMPLEMENTATION
 	#undef LOGURU_WITH_STREAMS
 	#define LOGURU_WITH_STREAMS 1
+#endif
+
+#ifndef LOGURU_USE_FMTLIB
+	#define LOGURU_USE_FMTLIB 0
 #endif
 
 // --------------------------------------------------------------------


### PR DESCRIPTION
[Fmtlib](https://github.com/fmtlib/fmt) has nice alternative, pythonlike, formatting. This patch allows fmtlib to be used by defining `LOGURU_USE_FMTLIB`

Tnx for sharing the `loguru` library btw 👍 