### PR TITLE
Implement a new feature

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,6 @@ add_executable(loguru_test ${source})
 
 find_package(Threads)
 target_link_libraries(loguru_test ${CMAKE_THREAD_LIBS_INIT}) # For pthreads
-if(!WIN32)
+if(NOT WIN32)
 	target_link_libraries(loguru_test dl) # For ldl
 endif()


### PR DESCRIPTION
A macro ``LOGURU_WITH_FILEABS`` is added.

when ``LOGURU_WITH_FILEABS`` is defined, a check of file change will be performed on every call to ``file_log``. If the file is moved, or inode changes, file is reopened using the same ``FileMode`` as is done by ``add_file``.

``file_log`` is made sequential using pthread lock since every call of ``file_log`` may reopen the file and invalidate the file descriptor. Hence calling ``file_log`` from multiple threads is OK.

Such a scheme is useful if you have a daemon program that moves the log file every 24 hours and expects new file to be created.

If one thread calls remove_callback while others are logging into this file, an error will probably occur. But I will let it be since I guess the very problem exists in the original design.