### PR TITLE
Improved Windows support

### DIFF
--- a/loguru.hpp
+++ b/loguru.hpp
@@ -258,7 +258,7 @@ Website: www.ilikebigbits.com
 
 // Used to mark log_and_abort for the benefit of the static analyzer and optimizer.
 #if defined(_MSC_VER)
-#define LOGURU_NORETURN
+#define LOGURU_NORETURN __declspec(noreturn)
 #else
 #define LOGURU_NORETURN __attribute__((noreturn))
 #endif
@@ -1730,8 +1730,8 @@ namespace loguru
 	#elif __APPLE__
 		strerror_r(errno, buff, sizeof(buff));
 		return Text(strdup(buff));
-	#elif WINDOWS
-		_strerror_s(buff, sizeof(buff));
+	#elif _WIN32
+		strerror_s(buff, sizeof(buff), errno);
 		return Text(strdup(buff));
 	#else
 		// Not thread-safe.
@@ -1746,7 +1746,7 @@ namespace loguru
 
 		s_argv0_filename = filename(argv[0]);
 
-		#ifdef WINDOWS
+		#ifdef _WIN32
 			#define getcwd _getcwd
 		#endif
 
@@ -2085,7 +2085,7 @@ namespace loguru
 		}
 #elif LOGURU_WINTHREADS
 		if (const char* name = get_thread_name_win32()) {
-			snprintf(buffer, length, "%s", name);
+			snprintf(buffer, (size_t)length, "%s", name);
 		} else {
 			buffer[0] = 0;
 		}

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -114,7 +114,7 @@ Website: www.ilikebigbits.com
 	LOGURU_DEBUG_LOGGING (default 1 #if !NDEBUG, else 0):
 		Enables debug versions of logging statements.
 
- 	LOGURU_DEBUG_CHECKS (default 1 #if !NDEBUG, else 0):
+	LOGURU_DEBUG_CHECKS (default 1 #if !NDEBUG, else 0):
 		Enables debug versions of checks.
 
 	LOGURU_REDEFINE_ASSERT (default 0):
@@ -1438,8 +1438,8 @@ namespace loguru
 	}();
 
 	const auto PREAMBLE_EXPLAIN = textprintf("date       time         ( uptime  ) [%-*s]%*s:line     v| ",
-	                                         LOGURU_THREADNAME_WIDTH, " thread name/id",
-	                                         LOGURU_FILENAME_WIDTH, "file");
+											 LOGURU_THREADNAME_WIDTH, " thread name/id",
+											 LOGURU_FILENAME_WIDTH, "file");
 
 	#if LOGURU_PTLS_NAMES
 		static pthread_once_t s_pthread_key_once = PTHREAD_ONCE_INIT;


### PR DESCRIPTION
Hi,
I've just started using this library and noticed a couple of issues during the compilation on Win. Most importantly, "_strerror_s" was used incorrectly and there was a #ifdef WINDOWS check that was never defined.

I also added support for terminal colors on Windows 10 (support checked at runtime and simply disabled for older versions). Unfortunately this required me to define more verbose sequence codes, because the \e variant doesn't work on Windows (See diff).