### PR TITLE
Let Clang and GCC also use WinAPI on Windows, fix #51

### DIFF
--- a/loguru.hpp
+++ b/loguru.hpp
@@ -1308,7 +1308,7 @@ This will define all the Loguru functions so that the linker may find them.
 #include <thread>
 #include <vector>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 	#include <direct.h>
 
 	#define localtime_r(a, b) localtime_s(b, a) // No localtime_r with MSVC, but arguments are swapped for localtime_s
@@ -1625,7 +1625,7 @@ namespace loguru
 	LOGURU_PRINTF_LIKE(1, 0)
 	static Text vtextprintf(const char* format, va_list vlist)
 	{
-#ifdef _MSC_VER
+#ifdef _WIN32
 		int bytes_needed = _vscprintf(format, vlist);
 		CHECK_F(bytes_needed >= 0, "Bad string format: '%s'", format);
 		char* buff = (char*)malloc(bytes_needed+1);
@@ -1940,7 +1940,7 @@ namespace loguru
 		for (char* p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
 			*p = '\0';
 
-	#ifdef _MSC_VER
+	#ifdef _WIN32
 			if (_mkdir(file_path) == -1) {
 	#else
 			if (mkdir(file_path, 0755) == -1) {


### PR DESCRIPTION
Tested with clang++ 5.0.0 from MSYS2. `_WIN32` is also defined for Visual Studio.