### PR TITLE
Fixed compilation error on Visual Studio 2017

### DIFF
--- a/loguru.hpp
+++ b/loguru.hpp
@@ -1375,6 +1375,9 @@ This will define all the Loguru functions so that the linker may find them.
 
 #define LOGURU_PREAMBLE_WIDTH (53 + LOGURU_THREADNAME_WIDTH + LOGURU_FILENAME_WIDTH)
 
+#undef min;
+#undef max;
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>


### PR DESCRIPTION
The error was caused by macros being defined in one of the Windows SDK source file (minwindef.h to be exact). Simply undefining those macros fix issue and doesn't affect code since these macros are not used anyway.