### PR TITLE
Fix REDEFINE_ASSERT behavior.

### DIFF
--- a/loguru.hpp
+++ b/loguru.hpp
@@ -1024,7 +1024,7 @@ namespace loguru
 #endif // NDEBUG
 
 
-#ifdef LOGURU_REDEFINE_ASSERT
+#if LOGURU_REDEFINE_ASSERT
 	#undef assert
 	#ifndef NDEBUG
 		// Debug:


### PR DESCRIPTION
This macro should be defined to 0 or 1 to disable/enable, but was tested with `#ifdef` such that it was always enabled.