### PR TITLE
Don't try to enable stacktraces on Android by default

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -71,7 +71,7 @@
 	#ifndef LOGURU_STACKTRACES
 		#define LOGURU_STACKTRACES 0
 	#endif
-#elif defined(__rtems__)
+#elif defined(__rtems__) || defined(__ANDROID__)
 	#define LOGURU_PTHREADS    1
 	#define LOGURU_WINTHREADS  0
 	#ifndef LOGURU_STACKTRACES


### PR DESCRIPTION
The Android NDK is missing `execinfo.h` so compilation fails. This PR treats Android systems like RTEMS systems, i.e. pthreads but no stacktrace support unless forced to do so.