### PR TITLE
Check for __GLIBC__ before enabling LOGURU_STACKTRACES

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -71,7 +71,7 @@
 	#ifndef LOGURU_STACKTRACES
 		#define LOGURU_STACKTRACES 0
 	#endif
-#elif defined(__rtems__) || defined(__ANDROID__)
+#elif defined(__rtems__) || !defined(__GLIBC__)
 	#define LOGURU_PTHREADS    1
 	#define LOGURU_WINTHREADS  0
 	#ifndef LOGURU_STACKTRACES


### PR DESCRIPTION
`LOGURU_STACKTRACES` depends on `execinfo.h`. However, not only is `execinfo.h` unavailable on Android, it's strictly a glibc extension, so everything that is POSIX, but not using glibc is not going to compile loguru (except, currently, Adroid).
Like I said in #86, `__GLIBC__` evaluates to the major version number of glibc. Alternatives are `__GLIBC_MINOR__` and `__GNU_LIBRARY__`.

ping @jtalowell

Fixes #86 