### PR TITLE
Only compile loguru_bench.cpp for loguru_bench

### DIFF
--- a/loguru_bench/CMakeLists.txt
+++ b/loguru_bench/CMakeLists.txt
@@ -13,7 +13,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Werror -Wall -Wextra")
 
 file(GLOB source
     "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/../*.cpp"
 )
 
 add_executable(loguru_bench ${source})


### PR DESCRIPTION
The CMakeLists.txt was compiling both loguru_bench.cpp and loguru.cpp from the
root folder. This causes linking errors, as loguru_bench.cpp already includes
loguru.cpp.