### PR TITLE
Some minor changes to silence compiler warnings

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1,3 +1,4 @@
+#ifndef _WIN32
 // Disable all warnings from gcc/clang:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
@@ -15,6 +16,7 @@
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-macros"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
 
 #include "loguru.hpp"
 

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -930,6 +930,9 @@ namespace loguru
 
 	void get_thread_name(char* buffer, unsigned long long length, bool right_align_hext_id)
 	{
+#ifdef _WIN32
+		(void)right_align_hext_id;
+#endif
 		CHECK_NE_F(length, 0u, "Zero length buffer in get_thread_name");
 		CHECK_NOTNULL_F(buffer, "nullptr in get_thread_name");
 #if LOGURU_PTHREADS

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -512,17 +512,17 @@ namespace loguru
 		char buff[256];
 	#if defined(__GLIBC__) && defined(_GNU_SOURCE)
 		// GNU Version
-		return Text(strdup(strerror_r(errno, buff, sizeof(buff))));
+		return Text(STRDUP(strerror_r(errno, buff, sizeof(buff))));
 	#elif defined(__APPLE__) || _POSIX_C_SOURCE >= 200112L
 		// XSI Version
 		strerror_r(errno, buff, sizeof(buff));
 		return Text(strdup(buff));
 	#elif defined(_WIN32)
 		strerror_s(buff, sizeof(buff), errno);
-		return Text(strdup(buff));
+		return Text(STRDUP(buff));
 	#else
 		// Not thread-safe.
-		return Text(strdup(strerror(errno)));
+		return Text(STRDUP(strerror(errno)));
 	#endif
 	}
 
@@ -675,7 +675,7 @@ namespace loguru
 	bool create_directories(const char* file_path_const)
 	{
 		CHECK_F(file_path_const && *file_path_const);
-		char* file_path = strdup(file_path_const);
+		char* file_path = STRDUP(file_path_const);
 		for (char* p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
 			*p = '\0';
 
@@ -903,7 +903,7 @@ namespace loguru
 	{
 		#if LOGURU_PTLS_NAMES
 			(void)pthread_once(&s_pthread_key_once, make_pthread_key_name);
-			(void)pthread_setspecific(s_pthread_key_name, strdup(name));
+			(void)pthread_setspecific(s_pthread_key_name, STRDUP(name));
 
 		#elif LOGURU_PTHREADS
 			#ifdef __APPLE__
@@ -984,7 +984,7 @@ namespace loguru
 	{
 		int status = -1;
 		char* demangled = abi::__cxa_demangle(name, 0, 0, &status);
-		Text result{status == 0 ? demangled : strdup(name)};
+		Text result{status == 0 ? demangled : STRDUP(name)};
 		return result;
 	}
 
@@ -1092,7 +1092,7 @@ namespace loguru
 #else // LOGURU_STACKTRACES
 	Text demangle(const char* name)
 	{
-		return Text(strdup(name));
+		return Text(STRDUP(name));
 	}
 
 	std::string stacktrace_as_stdstring(int)
@@ -1106,7 +1106,7 @@ namespace loguru
 	Text stacktrace(int skip)
 	{
 		auto str = stacktrace_as_stdstring(skip + 1);
-		return Text(strdup(str.c_str()));
+		return Text(STRDUP(str.c_str()));
 	}
 
 	// ------------------------------------------------------------------------
@@ -1555,7 +1555,7 @@ namespace loguru
 			}
 			result.str += "------------------------------------------------";
 		}
-		return Text(strdup(result.str.c_str()));
+		return Text(STRDUP(result.str.c_str()));
 	}
 
 	EcEntryBase::EcEntryBase(const char* file, unsigned line, const char* descr)
@@ -1578,7 +1578,7 @@ namespace loguru
 		// Add quotes around the string to make it obvious where it begin and ends.
 		// This is great for detecting erroneous leading or trailing spaces in e.g. an identifier.
 		auto str = "\"" + std::string(value) + "\"";
-		return Text{strdup(str.c_str())};
+		return Text{STRDUP(str.c_str())};
 	}
 
 	Text ec_to_text(char c)
@@ -1616,14 +1616,14 @@ namespace loguru
 
 		str += "'";
 
-		return Text{strdup(str.c_str())};
+		return Text{STRDUP(str.c_str())};
 	}
 
 	#define DEFINE_EC(Type)                        \
 		Text ec_to_text(Type value)                \
 		{                                          \
 			auto str = std::to_string(value);      \
-			return Text{strdup(str.c_str())};      \
+			return Text{STRDUP(str.c_str())};      \
 		}
 
 	DEFINE_EC(int)

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -232,6 +232,12 @@ Website: www.ilikebigbits.com
 	#include <fmt/format.h>
 #endif
 
+#ifdef _WIN32
+	#define STRDUP(str) _strdup(str)
+#else
+	#define STRDUP(str) strdup(str)
+#endif
+
 // --------------------------------------------------------------------
 
 namespace loguru
@@ -878,14 +884,14 @@ namespace loguru
 			{
 				// Called only when needed, i.e. on a crash.
 				std::string str = small_value.as_string(); // Format 'small_value' here somehow.
-				return Text{strdup(str.c_str())};
+				return Text{STRDUP(str.c_str())};
 			}
 
 			Text ec_to_text(const MyBigType* big_value)
 			{
 				// Called only when needed, i.e. on a crash.
 				std::string str = big_value->as_string(); // Format 'big_value' here somehow.
-				return Text{strdup(str.c_str())};
+				return Text{STRDUP(str.c_str())};
 			}
 		} // namespace loguru
 


### PR DESCRIPTION
Hi there,

Attached some changes to silence compiler warnings.

47cae1c Deactivates the diagnostic pragmas on Windows as VS doesn't recognise them.

576caad Visual Studio complains about an unofficial strdup which we all know works everywhere, but as it turns out is not part of the official spec. This commit changes the use of strdup per os.

54a6613 On windows `right_align_hext_id` is not used and Visual studio complains about that.

There are other ways to achieve the same, but see this as a proposal.