### PR TITLE
Add "screen.xterm-256color" as a recognized color TERM value

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -215,6 +215,7 @@ namespace loguru
 					|| 0 == strcmp(term, "rxvt-unicode-256color")
 					|| 0 == strcmp(term, "screen")
 					|| 0 == strcmp(term, "screen-256color")
+					|| 0 == strcmp(term, "screen.xterm-256color")
 					|| 0 == strcmp(term, "tmux-256color")
 					|| 0 == strcmp(term, "xterm")
 					|| 0 == strcmp(term, "xterm-256color")


### PR DESCRIPTION
Some versions of screen use this TERM value instead. For example, some versions of Ubuntu and Amazon Linux it seems.
https://bugs.launchpad.net/ubuntu/+source/gnome-terminal/+bug/1726826