### PR TITLE
Add pragmas to disable msvc warning 4018

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -16,6 +16,11 @@
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-macros"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#else
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4018)
+#endif // _MSC_VER
 #endif
 
 #include "loguru.hpp"
@@ -1790,6 +1795,12 @@ namespace loguru
 	}
 } // namespace loguru
 
+#endif // _WIN32
+
+#ifdef _WIN32
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
 #endif // _WIN32
 
 #endif // LOGURU_IMPLEMENTATION


### PR DESCRIPTION
This commit will get rid of the signed/unsigned mismatch warnings that are generated by MSVC due to lack of explicit casting. 

https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4018?view=vs-2019