### PR TITLE
Don't try to enable stacktraces on FreeBSD by default

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -78,7 +78,7 @@
 	#ifndef LOGURU_STACKTRACES
 		#define LOGURU_STACKTRACES 0
 	#endif
-#elif defined(__rtems__) || defined(__ANDROID__)
+#elif defined(__rtems__) || defined(__ANDROID__) || defined(__FreeBSD__)
 	#define LOGURU_PTHREADS    1
 	#define LOGURU_WINTHREADS  0
 	#ifndef LOGURU_STACKTRACES


### PR DESCRIPTION
Unlike Android, FreeBSD has execinfo.h, but doesn't have all the
symbols (missing at least backtrace and backtrace_symbols).
This change treats FreeBSD like Android and RTEMS systems, i.e.
pthreads but no stacktrace support unless forced to do so.