### PR TITLE
Fix compiler warnings on ARM platform

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -507,7 +507,7 @@ namespace loguru
 
 	static void escape(std::string& out, const std::string& str)
 	{
-		for (char c : str) {
+		for (signed char c : str) {
 			/**/ if (c == '\a') { out += "\\a";  }
 			else if (c == '\b') { out += "\\b";  }
 			else if (c == '\f') { out += "\\f";  }
@@ -1189,7 +1189,7 @@ namespace loguru
 		localtime_r(&sec_since_epoch, &time_info);
 
 		auto uptime_ms = duration_cast<milliseconds>(steady_clock::now() - s_start_time).count();
-		auto uptime_sec = uptime_ms / 1000.0;
+		auto uptime_sec = static_cast<double>(uptime_ms) / 1000.0;
 
 		char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
 		get_thread_name(thread_name, LOGURU_THREADNAME_WIDTH + 1, true);
@@ -1440,7 +1440,7 @@ namespace loguru
 				}
 			}
 #if LOGURU_VERBOSE_SCOPE_ENDINGS
-			auto duration_sec = (now_ns() - _start_time_ns) / 1e9;
+			auto duration_sec = static_cast<double>(now_ns() - _start_time_ns) / 1e9;
 #if LOGURU_USE_FMTLIB
 			auto buff = textprintf("{:.{}f} s: {:s}", duration_sec, LOGURU_SCOPE_TIME_PRECISION, _name);
 #else
@@ -1653,7 +1653,7 @@ namespace loguru
 		return Text{STRDUP(str.c_str())};
 	}
 
-	Text ec_to_text(char c)
+	Text ec_to_text(signed char c)
 	{
 		// Add quotes around the character to make it obvious where it begin and ends.
 		std::string str = "'";


### PR DESCRIPTION
Fix compiler warnings on ARM platform. Was building on a Raspberry Pi 3 running 64-bit Ubuntu.

I guess `char` defaults to `unsigned char` on ARM, and it didn't like the implicit `double` casts.

```
/XXX/loguru.cpp: In function ‘void loguru::escape(std::string&, const string&)’:
/XXX/loguru.cpp:522:15: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  522 |    else if (0 <= c && c < 0x20) { // ASCI control character:
      |             ~~^~~~
/XXX/loguru.cpp: In function ‘void loguru::print_preamble(char*, size_t, loguru::Verbosity, const char*, unsigned int)’:
/XXX/loguru.cpp:1192:21: error: conversion from ‘long int’ to ‘double’ may change value [-Werror=conversion]
 1192 |   auto uptime_sec = uptime_ms / 1000.0;
      |                     ^~~~~~~~~
/XXX/loguru.cpp: In destructor ‘loguru::LogScopeRAII::~LogScopeRAII()’:
/XXX/loguru.cpp:1443:34: error: conversion from ‘long long int’ to ‘double’ may change value [-Werror=conversion]
 1443 |    auto duration_sec = (now_ns() - _start_time_ns) / 1e9;
      |                        ~~~~~~~~~~^~~~~~~~~~~~~~~~~
/XXX/loguru.cpp: In function ‘loguru::Text loguru::ec_to_text(char)’:
/XXX/loguru.cpp:1684:14: error: comparison is always true due to limited range of data type [-Werror=type-limits]
 1684 |   else if (0 <= c && c < 0x20) {
      |            ~~^~~~
```