### PR TITLE
Avoid MSVC-specific functions with MinGW

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -695,7 +695,11 @@ namespace loguru
 
 	const char* home_dir()
 	{
-		#ifdef _WIN32
+		#ifdef __MINGW32__
+			auto home = getenv("USERPROFILE");
+			CHECK_F(home != nullptr, "Missing USERPROFILE");
+			return home;
+		#elif defined(_WIN32)
 			char* user_profile;
 			size_t len;
 			errno_t err = _dupenv_s(&user_profile, &len, "USERPROFILE");


### PR DESCRIPTION
`_dupenv_s` isn't available when compiling with MinGW (e.g. #128). This PR retrieves the Windows-specific `USERPROFILE` environment variable with the default `getenv` function.

Tested with MinGW 7.3.0 and MSVC14.22.