### PR TITLE
Fix typo and make it success when build with Clang 10

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -432,7 +432,7 @@ struct Options
 	// NOTE: on SOME platforms loguru::init will only overwrite the thread name
 	// if a thread name has not already been set.
 	// To always set a thread name, use loguru::set_thread_name instead.
-	const char+ main_thread_name = "main thread";
+	const char* main_thread_name = "main thread";
 
 	// Make Loguru try to do unsafe but useful things,
 	// like printing a stack trace, when catching signals.

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1189,7 +1189,7 @@ namespace loguru
 		localtime_r(&sec_since_epoch, &time_info);
 
 		auto uptime_ms = duration_cast<milliseconds>(steady_clock::now() - s_start_time).count();
-		auto uptime_sec = uptime_ms / 1000.0;
+		auto uptime_sec = static_cast<double> (uptime_ms) / 1000.0;
 
 		char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
 		get_thread_name(thread_name, LOGURU_THREADNAME_WIDTH + 1, true);
@@ -1440,7 +1440,7 @@ namespace loguru
 				}
 			}
 #if LOGURU_VERBOSE_SCOPE_ENDINGS
-			auto duration_sec = (now_ns() - _start_time_ns) / 1e9;
+			auto duration_sec = static_cast<double>(now_ns() - _start_time_ns) / 1e9;
 #if LOGURU_USE_FMTLIB
 			auto buff = textprintf("{:.{}f} s: {:s}", duration_sec, LOGURU_SCOPE_TIME_PRECISION, _name);
 #else

--- a/loguru_example/CMakeLists.txt
+++ b/loguru_example/CMakeLists.txt
@@ -22,6 +22,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-noreturn")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-prototypes")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-disabled-macro-expansion")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-implicit-int-float-conversion")
 endif() # Clang
 
 file(GLOB source

--- a/loguru_example/CMakeLists.txt
+++ b/loguru_example/CMakeLists.txt
@@ -23,7 +23,6 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-prototypes")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-gnu-zero-variadic-macro-arguments")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-disabled-macro-expansion")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-implicit-int-float-conversion")
 endif() # Clang
 
 file(GLOB source


### PR DESCRIPTION
Clang 10 will complain 2 kinds of errors in *loguru.cpp*:
  - disabled expansion of recursive macro [-Wdisabled-macro-expansion]: line 1784
  - implicit conversion from 'long long' to 'double' may lose precision [-Wimplicit-int-float-conversion]: line 1443

A simple switch off the warning will work.