### PR TITLE
fix inconsistency with LOGURU_USE_FMTLIB

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1564,6 +1564,7 @@ namespace loguru
 		s_needs_flushing = false;
 	}
 
+#if !LOGURU_USE_FMTLIB
 	LogScopeRAII::LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, const char* format, va_list vlist) :
 		_verbosity(verbosity), _file(file), _line(line)
 	{
@@ -1578,6 +1579,7 @@ namespace loguru
 		this->Init(format, vlist);
 		va_end(vlist);
 	}
+#endif
 
 	LogScopeRAII::~LogScopeRAII()
 	{
@@ -1609,13 +1611,21 @@ namespace loguru
 		}
 	}
 
+#if LOGURU_USE_FMTLIB
+	void LogScopeRAII::Init(const char* format, fmt::format_args args)
+#else
 	void LogScopeRAII::Init(const char* format, va_list vlist)
+#endif
 	{
 		if (_verbosity <= current_verbosity_cutoff()) {
 			std::lock_guard<std::recursive_mutex> lock(s_mutex);
 			_indent_stderr = (_verbosity <= g_stderr_verbosity);
 			_start_time_ns = now_ns();
+#if LOGURU_USE_FMTLIB
+			snprintf(_name, sizeof(_name), "%s", fmt::vformat(format, args).c_str());
+#else
 			vsnprintf(_name, sizeof(_name), format, vlist);
+#endif
 			log_to_everywhere(1, _verbosity, _file, _line, "{ ", _name);
 
 			if (_indent_stderr) {

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -664,11 +664,24 @@ namespace loguru
 	{
 	public:
 		LogScopeRAII() : _file(nullptr) {} // No logging
+#if LOGURU_USE_FMTLIB
+		template <typename... Args>
+		LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, const Args&... args) :
+			_verbosity(verbosity), _file(file), _line(line)
+		{
+			this->Init(format, fmt::make_format_args(args...));
+		}
+#else
 		LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, va_list vlist) LOGURU_PRINTF_LIKE(5, 0);
 		LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(5, 6);
+#endif
 		~LogScopeRAII();
 
+#if LOGURU_USE_FMTLIB
+		void Init(LOGURU_FORMAT_STRING_TYPE format, fmt::format_args args);
+#else
 		void Init(LOGURU_FORMAT_STRING_TYPE format, va_list vlist) LOGURU_PRINTF_LIKE(2, 0);
+#endif
 
 #if defined(_MSC_VER) && _MSC_VER > 1800
 		// older MSVC default move ctors close the scope on move. See


### PR DESCRIPTION
Scoped logs were still using printf syntax with USE_FMTLIB, this patch
changes those to also use fmtlib when appropriate.