### PR TITLE
Include fmt/ostream when using fmtlib

### DIFF
--- a/loguru.hpp
+++ b/loguru.hpp
@@ -231,6 +231,7 @@ Website: www.ilikebigbits.com
 
 #if LOGURU_USE_FMTLIB
 	#include <fmt/format.h>
+	#include <fmt/ostream.h>
 	#define LOGURU_FMT(x) "{:" #x "}"
 #else
 	#define LOGURU_FMT(x) "%" #x


### PR DESCRIPTION
This allows us to print user defined classes/struct that have only ostream operator defined.