### PR TITLE
Allow user to disable ptls names

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -112,7 +112,9 @@
 		   Additionally, all new threads inherit the name of the thread it got forked from.
 		   For this reason, Loguru use the pthread Thread Local Storage
 		   for storing thread names on Linux. */
-		#define LOGURU_PTLS_NAMES 1
+		#ifndef LOGURU_PTLS_NAMES
+			#define LOGURU_PTLS_NAMES 1
+		#endif
 	#endif
 #endif
 


### PR DESCRIPTION
Allows user to opt out of uset thread local storage for thread names. For some reason, I get weird hex names when using ptls for thread names on my system:
`2020-06-16 20:53:22.134 (   2.817s) [         AF61228]`
Without using ptls names everyhing works correctly.