### PR TITLE
Enabled support for pthreads on Solaris/illumos

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -582,7 +582,7 @@ namespace loguru
 			#elif LOGURU_PTHREADS
 				char old_thread_name[16] = {0};
 				auto this_thread = pthread_self();
-				#if defined(__APPLE__) || defined(__linux__)
+				#if defined(__APPLE__) || defined(__linux__) || defined(__sun)
 					pthread_getname_np(this_thread, old_thread_name, sizeof(old_thread_name));
 				#endif
 				if (old_thread_name[0] == 0) {
@@ -590,7 +590,7 @@ namespace loguru
 						pthread_setname_np(main_thread_name);
 					#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 						pthread_set_name_np(this_thread, main_thread_name);
-					#elif defined(__linux__)
+					#elif defined(__linux__) || defined(__sun)
 						pthread_setname_np(this_thread, main_thread_name);
 					#endif
 				}
@@ -948,7 +948,7 @@ namespace loguru
 				pthread_setname_np(name);
 			#elif defined(__FreeBSD__) || defined(__OpenBSD__)
 				pthread_set_name_np(pthread_self(), name);
-			#elif defined(__linux__)
+			#elif defined(__linux__) || defined(__sun)
 				pthread_setname_np(pthread_self(), name);
 			#endif
 		#elif LOGURU_WINTHREADS
@@ -981,7 +981,7 @@ namespace loguru
 			} else {
 				buffer[0] = 0;
 			}
-		#elif defined(__APPLE__) || defined(__linux__)
+		#elif defined(__APPLE__) || defined(__linux__) || defined(__sun)
 			pthread_getname_np(thread, buffer, length);
 		#else
 			buffer[0] = 0;


### PR DESCRIPTION
In the relevant use cases, Solaris/illumos has roughly the same API as Linux.