### PR TITLE
Use _fsopen vs fopen_s to allow sharing for log aggregators/rotators to access

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -752,8 +752,8 @@ namespace loguru
 		const char* mode_str = (mode == FileMode::Truncate ? "w" : "a");
 		FILE* file;
 	#ifdef _WIN32
-		errno_t file_error = fopen_s(&file, path, mode_str);
-		if (file_error) {
+		file = _fsopen(path, mode_str, _SH_DENYNO);
+		if (!file) {
 	#else
 		file = fopen(path, mode_str);
 		if (!file) {


### PR DESCRIPTION
Added quick change to add_file(...) to windows specific code to allow sharing of the log file so that other programs can read from it.