### PR TITLE
Rename signals to signal_options

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -652,7 +652,7 @@ namespace loguru
 		VLOG_F(g_internal_verbosity, "stderr verbosity: " LOGURU_FMT(d) "", g_stderr_verbosity);
 		VLOG_F(g_internal_verbosity, "-----------------------------------");
 
-		install_signal_handlers(options.signals);
+		install_signal_handlers(options.signal_options);
 
 		atexit(on_atexit);
 	}

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -453,7 +453,7 @@ namespace loguru
 		// To always set a thread name, use loguru::set_thread_name instead.
 		const char* main_thread_name = "main thread";
 
-		SignalOptions signals;
+		SignalOptions signal_options;
 	};
 
 	/*  Should be called from the main thread.


### PR DESCRIPTION
This PR proposes to rename the `SignalOptions` member in `Options` from `signals` to `signal_options`.
This avoids issues if the popular Qt library, which defines a macro called `signals` (see https://doc.qt.io/qt-5/signalsandslots.html), is included before loguru.

The `install_signal_handlers` function already calls its argument `const SignalOptions& signal_options`.