### PR TITLE
Cleanup static analyzer issues

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1807,6 +1807,7 @@ namespace loguru
 		Text parent_ec = get_error_context_for(ec_handle);
 		size_t buffer_size = strlen(parent_ec.c_str()) + 2;
 		char* with_newline = reinterpret_cast<char*>(malloc(buffer_size));
+		CHECK_F(with_newline != nullptr, "Failed to allocate memory for error context.");
 		with_newline[0] = '\n';
 	#ifdef _WIN32
 		strncpy_s(with_newline + 1, buffer_size, parent_ec.c_str(), buffer_size - 2);

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1629,7 +1629,7 @@ namespace loguru
 
 	struct StringStream
 	{
-		std::string str;
+		std::string str{};
 	};
 
 	// Use this in your EcPrinter implementations.

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1284,7 +1284,14 @@ namespace loguru
 			}
 		}
 		if (g_preamble_pipe && pos < out_buff_size) {
-			/* pos += */ (void)snprintf(out_buff + pos, out_buff_size - pos, "| ");
+			(void)snprintf(out_buff + pos, out_buff_size - pos, "| ");
+
+			// Because this is the last if-statement, we avoid incrementing the
+			//  position to clarify it's unused. If more cases are added, then:
+			// int bytes = snprintf(...)
+			// if (bytes > 0) {
+			// 	pos += bytes;
+			// }
 		}
 	}
 
@@ -1363,7 +1370,13 @@ namespace loguru
 			}
 		}
 		if (g_preamble_pipe && pos < out_buff_size) {
-			/* pos += */ (void)snprintf(out_buff + pos, out_buff_size - pos, "| ");
+			(void)snprintf(out_buff + pos, out_buff_size - pos, "| ");
+
+			// Avoid incrementing the position to clarify it's unused
+			// int bytes = snprintf(...)
+			// if (bytes > 0) {
+			// 	pos += bytes;
+			// }
 		}
 	}
 

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1264,7 +1264,7 @@ namespace loguru
 			pos += snprintf(out_buff + pos, out_buff_size - pos, "   v");
 		}
 		if (g_preamble_pipe && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "| ");
+			/* pos += */ snprintf(out_buff + pos, out_buff_size - pos, "| ");
 		}
 	}
 
@@ -1325,7 +1325,7 @@ namespace loguru
 			               level_buff);
 		}
 		if (g_preamble_pipe && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "| ");
+			/* pos += */ snprintf(out_buff + pos, out_buff_size - pos, "| ");
 		}
 	}
 

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -32,6 +32,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <chrono>
 #include <cstdarg>
 #include <cstdio>

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -40,6 +40,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <climits>
 #include <mutex>
 #include <regex>
 #include <string>
@@ -556,7 +557,11 @@ namespace loguru
 			else if (c == '\'') { out += "\\\'"; }
 			else if (c == '\"') { out += "\\\""; }
 			else if (c == ' ')  { out += "\\ ";  }
-			else if (0 <= c && c < 0x20) { // ASCI control character:
+#if (CHAR_MIN < 0) // char is signed
+			else if (0 <= c && c < 0x20) { // ASCI control character
+#else // char is unsigned
+			else if (c < 0x20) { // ASCI control character
+#endif
 			// else if (c < 0x20 || c != (c & 127)) { // ASCII control character or UTF-8:
 				out += "\\x";
 				write_hex_byte(out, static_cast<uint8_t>(c));
@@ -1773,7 +1778,11 @@ namespace loguru
 		else if (c == '\n') { str += "\\n";  }
 		else if (c == '\r') { str += "\\r";  }
 		else if (c == '\t') { str += "\\t";  }
+#if (CHAR_MIN < 0) // char is signed
 		else if (0 <= c && c < 0x20) {
+#else // char is unsigned
+		else if (c < 0x20) {
+#endif
 			str += "\\u";
 			write_hex_16(static_cast<uint16_t>(c));
 		} else { str += c; }

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1312,12 +1312,12 @@ namespace loguru
 			file = filename(file);
 		}
 
-		char level_buff[6];
+		char level_buff[7];
 		const char* custom_level_name = get_verbosity_name(verbosity);
 		if (custom_level_name) {
 			snprintf(level_buff, sizeof(level_buff) - 1, "%s", custom_level_name);
 		} else {
-			snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", verbosity);
+			snprintf(level_buff, sizeof(level_buff) - 1, "%4d", static_cast<int>(verbosity) % 9999);
 		}
 
 		size_t pos = 0;

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1196,8 +1196,7 @@ namespace loguru
 				}
 				snprintf(buf, sizeof(buf), "%-3d %*p %s + %zd\n",
 						 i - skip, int(2 + sizeof(void*) * 2), callstack[i],
-						 status == 0 ? demangled :
-						 info.dli_sname == 0 ? symbols[i] : info.dli_sname,
+						 status == 0 ? demangled : info.dli_sname,
 						 static_cast<char*>(callstack[i]) - static_cast<char*>(info.dli_saddr));
 				free(demangled);
 			} else {

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -128,7 +128,9 @@
 		#define _WIN32_WINNT 0x0502
 	#endif
 	#define WIN32_LEAN_AND_MEAN
-	#define NOMINMAX
+	#ifndef NOMINMAX
+		#define NOMINMAX
+	#endif
 	#include <windows.h>
 #endif
 

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -599,7 +599,7 @@ namespace loguru
 			LOG_F(WARNING, "Failed to get current working directory: " LOGURU_FMT(s) "", error_text.c_str());
 		}
 
-		s_arguments = "";
+		s_arguments.clear();
 		for (int i = 0; i < argc; ++i) {
 			escape(s_arguments, argv[i]);
 			if (i + 1 < argc) {
@@ -645,7 +645,7 @@ namespace loguru
 			fflush(stderr);
 		}
 		VLOG_F(g_internal_verbosity, "arguments: " LOGURU_FMT(s) "", s_arguments.c_str());
-		if (strlen(s_current_dir) != 0)
+		if (s_current_dir[0] != '\0')
 		{
 			VLOG_F(g_internal_verbosity, "Current dir: " LOGURU_FMT(s) "", s_current_dir);
 		}
@@ -817,7 +817,7 @@ namespace loguru
 		if (!s_arguments.empty()) {
 			fprintf(file, "arguments: %s\n", s_arguments.c_str());
 		}
-		if (strlen(s_current_dir) != 0) {
+		if (s_current_dir[0] != '\0') {
 			fprintf(file, "Current dir: %s\n", s_current_dir);
 		}
 		fprintf(file, "File verbosity level: %d\n", verbosity);

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1,4 +1,4 @@
-#ifndef _WIN32
+#if defined(__GNUC__) || defined(__clang__)
 // Disable all warnings from gcc/clang:
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
@@ -11,16 +11,13 @@
 #pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #pragma GCC diagnostic ignored "-Wpadded"
-#pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wunused-macros"
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
-#else
-#ifdef _MSC_VER
+#elif defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable:4018)
-#endif // _MSC_VER
+#pragma warning(disable:4365) // conversion from 'X' to 'Y', signed/unsigned mismatch
 #endif
 
 #include "loguru.hpp"
@@ -1249,27 +1246,45 @@ namespace loguru
 	{
 		if (out_buff_size == 0) { return; }
 		out_buff[0] = '\0';
-		long pos = 0;
-		if (g_preamble_date) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "date       ");
+		size_t pos = 0;
+		if (g_preamble_date && pos < out_buff_size) {
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "date       ");
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_time && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "time         ");
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "time         ");
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_uptime && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "( uptime  ) ");
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "( uptime  ) ");
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_thread && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "[%-*s]", LOGURU_THREADNAME_WIDTH, " thread name/id");
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "[%-*s]", LOGURU_THREADNAME_WIDTH, " thread name/id");
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_file && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "%*s:line  ", LOGURU_FILENAME_WIDTH, "file");
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "%*s:line  ", LOGURU_FILENAME_WIDTH, "file");
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_verbose && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "   v");
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "   v");
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_pipe && pos < out_buff_size) {
-			/* pos += */ snprintf(out_buff + pos, out_buff_size - pos, "| ");
+			/* pos += */ (void)snprintf(out_buff + pos, out_buff_size - pos, "| ");
 		}
 	}
 
@@ -1301,36 +1316,54 @@ namespace loguru
 			snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", verbosity);
 		}
 
-		long pos = 0;
+		size_t pos = 0;
 
-		if (g_preamble_date) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "%04d-%02d-%02d ",
-				             1900 + time_info.tm_year, 1 + time_info.tm_mon, time_info.tm_mday);
+		if (g_preamble_date && pos < out_buff_size) {
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "%04d-%02d-%02d ",
+				                 1900 + time_info.tm_year, 1 + time_info.tm_mon, time_info.tm_mday);
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_time && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "%02d:%02d:%02d.%03lld ",
-			               time_info.tm_hour, time_info.tm_min, time_info.tm_sec, ms_since_epoch % 1000);
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "%02d:%02d:%02d.%03lld ",
+			                     time_info.tm_hour, time_info.tm_min, time_info.tm_sec, ms_since_epoch % 1000);
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_uptime && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "(%8.3fs) ",
-			               uptime_sec);
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "(%8.3fs) ",
+			                     uptime_sec);
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_thread && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "[%-*s]",
-			               LOGURU_THREADNAME_WIDTH, thread_name);
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "[%-*s]",
+			                     LOGURU_THREADNAME_WIDTH, thread_name);
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_file && pos < out_buff_size) {
 			char shortened_filename[LOGURU_FILENAME_WIDTH + 1];
 			snprintf(shortened_filename, LOGURU_FILENAME_WIDTH + 1, "%s", file);
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "%*s:%-5u ",
-			               LOGURU_FILENAME_WIDTH, shortened_filename, line);
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "%*s:%-5u ",
+			                     LOGURU_FILENAME_WIDTH, shortened_filename, line);
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_verbose && pos < out_buff_size) {
-			pos += snprintf(out_buff + pos, out_buff_size - pos, "%4s",
-			               level_buff);
+			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "%4s",
+			                     level_buff);
+			if (bytes > 0) {
+				pos += bytes;
+			}
 		}
 		if (g_preamble_pipe && pos < out_buff_size) {
-			/* pos += */ snprintf(out_buff + pos, out_buff_size - pos, "| ");
+			/* pos += */ (void)snprintf(out_buff + pos, out_buff_size - pos, "| ");
 		}
 	}
 
@@ -1969,10 +2002,11 @@ namespace loguru
 
 #endif // _WIN32
 
-#ifdef _WIN32
-#ifdef _MSC_VER
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
 #pragma warning(pop)
-#endif // _MSC_VER
-#endif // _WIN32
+#endif
 
 #endif // LOGURU_IMPLEMENTATION

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1858,7 +1858,10 @@ namespace loguru
 		memset(&sig_action, 0, sizeof(sig_action));
 		sigemptyset(&sig_action.sa_mask);
 		sig_action.sa_handler = SIG_DFL;
-		sigaction(signal_number, &sig_action, NULL);
+
+		// Note: Explicitly ignore sigaction's return value.
+		//       It's only used when setting up the signal handlers.
+		(void) sigaction(signal_number, &sig_action, NULL);
 		kill(getpid(), signal_number);
 	}
 

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1247,7 +1247,8 @@ namespace loguru
 		if (out_buff_size == 0) { return; }
 		out_buff[0] = '\0';
 		size_t pos = 0;
-		if (g_preamble_date && pos < out_buff_size) {
+		assert(pos < out_buff_size);
+		if (g_preamble_date) {
 			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "date       ");
 			if (bytes > 0) {
 				pos += bytes;
@@ -1324,8 +1325,8 @@ namespace loguru
 		}
 
 		size_t pos = 0;
-
-		if (g_preamble_date && pos < out_buff_size) {
+		assert(pos < out_buff_size);
+		if (g_preamble_date) {
 			int bytes = snprintf(out_buff + pos, out_buff_size - pos, "%04d-%02d-%02d ",
 				                 1900 + time_info.tm_year, 1 + time_info.tm_mon, time_info.tm_mday);
 			if (bytes > 0) {

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1163,7 +1163,7 @@ namespace loguru
 
 		try {
 			std::regex std_allocator_re(R"(,\s*std::allocator<[^<>]+>)");
-			output = std::regex_replace(output, std_allocator_re, std::string(""));
+			output = std::regex_replace(output, std_allocator_re, std::string());
 
 			std::regex template_spaces_re(R"(<\s*([^<> ]+)\s*>)");
 			output = std::regex_replace(output, template_spaces_re, std::string("<$1>"));

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -898,7 +898,7 @@ namespace loguru
 			return;
 		}
 
-		s_user_stack_cleanups.push_back(StringPair(find_this, replace_with_this));
+		s_user_stack_cleanups.emplace_back(StringPair(find_this, replace_with_this));
 	}
 
 	static void on_callback_change()

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1245,7 +1245,7 @@ namespace loguru
 		if (out_buff_size == 0) { return; }
 		out_buff[0] = '\0';
 		long pos = 0;
-		if (g_preamble_date && pos < out_buff_size) {
+		if (g_preamble_date) {
 			pos += snprintf(out_buff + pos, out_buff_size - pos, "date       ");
 		}
 		if (g_preamble_time && pos < out_buff_size) {
@@ -1298,7 +1298,7 @@ namespace loguru
 
 		long pos = 0;
 
-		if (g_preamble_date && pos < out_buff_size) {
+		if (g_preamble_date) {
 			pos += snprintf(out_buff + pos, out_buff_size - pos, "%04d-%02d-%02d ",
 				             1900 + time_info.tm_year, 1 + time_info.tm_mon, time_info.tm_mday);
 		}

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -747,6 +747,7 @@ namespace loguru
 	{
 		CHECK_F(file_path_const && *file_path_const);
 		char* file_path = STRDUP(file_path_const);
+		CHECK_F(file_path != nullptr, "Failed to allocate memory");
 		for (char* p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
 			*p = '\0';
 

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1029,7 +1029,7 @@ namespace loguru
 	// Where we store the custom thread name set by `set_thread_name`
 	char* thread_name_buffer()
 	{
-		__declspec( thread ) static char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
+		static char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
 		return &thread_name[0];
 	}
 #endif // LOGURU_WINTHREADS

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -674,12 +674,12 @@ namespace loguru
 		LogScopeRAII& operator=(const LogScopeRAII&) = delete;
 		void operator=(LogScopeRAII&&) = delete;
 
-		Verbosity   _verbosity;
-		const char* _file; // Set to null if we are disabled due to verbosity
-		unsigned    _line;
+		Verbosity   _verbosity = Verbosity_INVALID;
+		const char* _file = nullptr; // Set to null if we are disabled due to verbosity
+		unsigned    _line = 0;
 		bool        _indent_stderr = false; // Did we?
 		long long   _start_time_ns = 0;
-		char        _name[LOGURU_SCOPE_TEXT_SIZE];
+		char        _name[LOGURU_SCOPE_TEXT_SIZE] = {};
 	};
 
 	// Marked as 'noreturn' for the benefit of the static analyzer and optimizer.

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -677,8 +677,8 @@ namespace loguru
 		Verbosity   _verbosity;
 		const char* _file; // Set to null if we are disabled due to verbosity
 		unsigned    _line;
-		bool        _indent_stderr; // Did we?
-		long long   _start_time_ns;
+		bool        _indent_stderr = false; // Did we?
+		long long   _start_time_ns = 0;
 		char        _name[LOGURU_SCOPE_TEXT_SIZE];
 	};
 
@@ -834,7 +834,7 @@ namespace loguru
 		const char*  _file;
 		unsigned     _line;
 		const char*  _descr;
-		EcEntryBase* _previous;
+		EcEntryBase* _previous = nullptr;
 	};
 
 	template<typename T>

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -820,7 +820,7 @@ namespace loguru
 	{
 	public:
 		EcEntryBase(const char* file, unsigned line, const char* descr);
-		~EcEntryBase();
+		virtual ~EcEntryBase();
 		EcEntryBase(const EcEntryBase&) = delete;
 		EcEntryBase(EcEntryBase&&) = delete;
 		EcEntryBase& operator=(const EcEntryBase&) = delete;


### PR DESCRIPTION
This PR fixes issues flagged by the Clang static analyzer, Coverity, and PVS Studio.
Suggest reviewing commit-by-commit, for which the following provides more background.

---

### Uninitialized member variables, flagged by GCC and PVS Studio

``` text
../submodules/loguru/loguru.cpp:1491:9: warning: 'loguru::LogScopeRAII::_indent_stderr' should be initialized in the member initialization list
../submodules/loguru/loguru.cpp:1491:9: warning: 'loguru::LogScopeRAII::_start_time_ns' should be initialized in the member initialization list
../submodules/loguru/loguru.cpp:1630:16: warning: 'loguru::StringStream::str' should be initialized in the member initialization list
../submodules/loguru/loguru.cpp:1725:9: warning: 'loguru::EcEntryBase::_previous' should be initialized in the member initialization list 
```

![2021-08-22_20-25](https://user-images.githubusercontent.com/1557255/130398325-30487af1-1a18-4602-962d-842ea8d0c4b6.png)

---

### Unused position increment (clarify intent), flagged by Clang's static analyzer

![2021-08-22_22-59](https://user-images.githubusercontent.com/1557255/130398318-2f49d472-aa68-4397-b165-1e65b55dd01f.png)

---

### Simplify empty `std::string` operations (1/2), flagged by PVS Studio

![2021-08-22_22-46](https://user-images.githubusercontent.com/1557255/130398319-0996af5f-5d4f-4aaf-b874-ead658c3f46e.png)

### Simplify empty `std::string` operations (2/2), flagged by PVS Studio

![2021-08-22_20-40](https://user-images.githubusercontent.com/1557255/130398322-d444cc21-8f57-4e08-985b-f77a99cc6010.png)

---

### Potential nullptr dereference, flagged by PVS Studio

![2021-08-22_20-47](https://user-images.githubusercontent.com/1557255/130398320-faf81cda-5489-42cf-8b20-dbc3c96a02e0.png)

---

### Clarify criteria by removing redundancy, flagged by PVS Studio

![2021-08-22_20-42](https://user-images.githubusercontent.com/1557255/130398321-15d2afdb-3968-450b-98b4-a5a4d93692c6.png)

![2021-08-22_20-36](https://user-images.githubusercontent.com/1557255/130398324-99e52ba4-3311-46a3-9c0c-b19898ed0ca5.png)

If it makes sense to keep keep them, I could see them be valid as assert`s or `CHECK_F`s -- let me know.

---

### Virtualize EcEntryBase's destructor so it's called by derived classes, flagged by LGTM

![2021-08-24_12-24](https://user-images.githubusercontent.com/1557255/130679923-5d1bf6b7-89b5-45ed-add0-6ddc72f407bc.png)

---

### Explicitly ignore sigaction's return value, flagged by Coverity

![2021-08-24_12-23](https://user-images.githubusercontent.com/1557255/130680002-81adf118-c14b-428f-a69f-4dd52884084b.png)
