### PR TITLE
fix: NOMINMAX defined in system header

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -126,7 +126,9 @@
 		#define _WIN32_WINNT 0x0502
 	#endif
 	#define WIN32_LEAN_AND_MEAN
-	#define NOMINMAX
+	#ifndef NOMINMAX
+		#define NOMINMAX
+	#endif
 	#include <windows.h>
 #endif
 


### PR DESCRIPTION
Sometimes, NOMINMAX defined by system header at mingw64/include/c++/10.3.0/x86_64-w64-mingw32/bits/os_defines.h:45
![image](https://user-images.githubusercontent.com/46394906/135425949-ae9a8cb5-f93d-4e22-8784-5cfafe06a336.png)
