### PR TITLE
Fix a compilation warning - directive output may be truncated

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1311,7 +1311,7 @@ namespace loguru
 		if (custom_level_name) {
 			snprintf(level_buff, sizeof(level_buff) - 1, "%s", custom_level_name);
 		} else {
-			snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", (int8_t)verbosity);
+			snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", static_cast<int8_t>(verbosity));
 		}
 
 		size_t pos = 0;

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1311,7 +1311,7 @@ namespace loguru
 		if (custom_level_name) {
 			snprintf(level_buff, sizeof(level_buff) - 1, "%s", custom_level_name);
 		} else {
-			snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", verbosity);
+			snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", (int8_t)verbosity);
 		}
 
 		size_t pos = 0;


### PR DESCRIPTION
Add a simple solution to a compilation warning that doesn't require any special changes to be made to already existing enums, types or logic.

```
loguru/loguru.cpp: In function ‘void loguru::print_preamble(char*, size_t, loguru::Verbosity, const char*, unsigned int)’:
loguru/loguru.cpp:1208:50: warning: ‘% 4d’ directive output may be truncated writing between 4 and 11 bytes into a region of size 5 [-Wformat-truncation=]
 1208 |    snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", verbosity);
      |                                                  ^~~~
loguru/loguru.cpp:1208:49: note: directive argument in the range [1, 2147483647]
 1208 |    snprintf(level_buff, sizeof(level_buff) - 1, "% 4d", verbosity);
      |                                                 ^~~~~~
In file included from /usr/include/stdio.h:867,
                 from /usr/include/c++/9/cstdio:42,
                 from /usr/include/c++/9/ext/string_conversions.h:43,
                 from /usr/include/c++/9/bits/basic_string.h:6493,
                 from /usr/include/c++/9/string:55,
                 from /usr/include/c++/9/stdexcept:39,
                 from /usr/include/c++/9/array:39,
                 from /usr/include/c++/9/tuple:39,
                 from /usr/include/c++/9/functional:54,
                 from /usr/include/c++/9/pstl/glue_algorithm_defs.h:13,
                 from /usr/include/c++/9/algorithm:71,
                 from loguru/loguru.cpp:36:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:35: note: ‘__builtin___snprintf_chk’ output between 5 and 12 bytes into a destination of size 5
   67 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   68 |        __bos (__s), __fmt, __va_arg_pack ());
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```