### PR TITLE
add va_list versions of log functions and add optional anonymous namespace

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -134,6 +134,7 @@
    #define LOGURU_PTLS_NAMES 0
 #endif
 
+LOGURU_ANONYMOUS_NAMESPACE_BEGIN
 
 namespace loguru
 {
@@ -2017,5 +2018,7 @@ namespace loguru
 #elif defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+
+LOGURU_ANONYMOUS_NAMESPACE_END
 
 #endif // LOGURU_IMPLEMENTATION

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -248,6 +248,8 @@ Website: www.ilikebigbits.com
 	#define STRDUP(str) strdup(str)
 #endif
 
+#include <stdarg.h>
+
 // --------------------------------------------------------------------
 
 namespace loguru
@@ -635,6 +637,10 @@ namespace loguru
 	LOGURU_EXPORT
 	void log(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(4, 5);
 
+	// Actual logging function.
+	LOGURU_EXPORT
+	void vlog(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, va_list) LOGURU_PRINTF_LIKE(4, 0);
+
 	// Log without any preamble or indentation.
 	LOGURU_EXPORT
 	void raw_log(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(4, 5);
@@ -645,8 +651,11 @@ namespace loguru
 	{
 	public:
 		LogScopeRAII() : _file(nullptr) {} // No logging
+		LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, va_list vlist) LOGURU_PRINTF_LIKE(5, 0);
 		LogScopeRAII(Verbosity verbosity, const char* file, unsigned line, LOGURU_FORMAT_STRING_TYPE format, ...) LOGURU_PRINTF_LIKE(5, 6);
 		~LogScopeRAII();
+
+		void Init(LOGURU_FORMAT_STRING_TYPE format, va_list vlist) LOGURU_PRINTF_LIKE(2, 0);
 
 #if defined(_MSC_VER) && _MSC_VER > 1800
 		// older MSVC default move ctors close the scope on move. See

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -195,6 +195,14 @@ Website: www.ilikebigbits.com
 #endif
 #endif
 
+#ifdef LOGURU_USE_ANONYMOUS_NAMESPACE
+	#define LOGURU_ANONYMOUS_NAMESPACE_BEGIN namespace {
+	#define LOGURU_ANONYMOUS_NAMESPACE_END }
+#else
+	#define LOGURU_ANONYMOUS_NAMESPACE_BEGIN
+	#define LOGURU_ANONYMOUS_NAMESPACE_END
+#endif
+
 // --------------------------------------------------------------------
 // Utility macros
 
@@ -251,6 +259,7 @@ Website: www.ilikebigbits.com
 #include <stdarg.h>
 
 // --------------------------------------------------------------------
+LOGURU_ANONYMOUS_NAMESPACE_BEGIN
 
 namespace loguru
 {
@@ -1029,6 +1038,8 @@ namespace loguru
 	*/
 } // namespace loguru
 
+LOGURU_ANONYMOUS_NAMESPACE_END
+
 // --------------------------------------------------------------------
 // Logging macros
 
@@ -1198,6 +1209,8 @@ namespace loguru
 #include <sstream> // Adds about 38 kLoC on clang.
 #include <string>
 
+LOGURU_ANONYMOUS_NAMESPACE_BEGIN
+
 namespace loguru
 {
 	// Like sprintf, but returns the formated text.
@@ -1312,6 +1325,8 @@ namespace loguru
 	inline long long          referenceable_value(long long          t) { return t; }
 	inline unsigned long long referenceable_value(unsigned long long t) { return t; }
 } // namespace loguru
+
+LOGURU_ANONYMOUS_NAMESPACE_END
 
 // -----------------------------------------------
 // Logging macros:


### PR DESCRIPTION
These proposed changes are being used in the forked version Loguru used in ECP VTK-m.

Proposed changes are split into two commits:

- Encapsulate functions using anonymous, needed for other libraries using this libraries not to export the loguru namespace to avoid possible conflict when there are two libraries/binaries using different Loguru versions and being statically linked together.

- Add va_list version of the core functions, varadic MACROS are impossible to opaquely wrap, in this commit I propose an alternative.
