### PR TITLE
Fix exclusive file-lock on Windows

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -787,12 +787,11 @@ namespace loguru
 		const char* mode_str = (mode == FileMode::Truncate ? "w" : "a");
 		FILE* file;
 	#ifdef _WIN32
-		errno_t file_error = fopen_s(&file, path, mode_str);
-		if (file_error) {
+		file = _fsopen(path, mode_str, _SH_DENYNO);
 	#else
 		file = fopen(path, mode_str);
-		if (!file) {
 	#endif
+		if (!file) {
 			LOG_F(ERROR, "Failed to open '" LOGURU_FMT(s) "'", path);
 			return false;
 		}


### PR DESCRIPTION
Changes:
- Fixes #126

Notes:
- This fix was suggested by @lkho and it works perfectly, thanks!
- It might makes sense to allow shared read access but prevent shared write?
  This could be accomplished by switch `_SH_DENYNO` to `_SH_DENYWR`.
