### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,20 @@ CHECK_EQ_S(pi, 3.14) << "Maybe it is closer to " << M_PI;
 
 For more info, see [the official documentation](https://emilk.github.io/loguru/index.html).
 
+## Installing loguru (vcpkg)
+
+Alternatively, you can build and install loguru using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+``` bash or powershell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+./vcpkg install loguru
+```
+
+The loguru port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Grep:able logs
 ``` bash
 # Only show warnings, errors and fatal messages:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ For more info, see [the official documentation](https://emilk.github.io/loguru/i
 
 Alternatively, you can build and install loguru using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
 
-``` bash or powershell
+```bash
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 ./bootstrap-vcpkg.sh


### PR DESCRIPTION
`loguru` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `loguru` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `loguru`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/loguru/portfile.cmake). We try to keep the library maintained as close as possible to the original library. 

Other:
For different systems, `loguru` is used as a `header-only` library on windows. However, for `linux`, `vcpkg` provides [`CMakeLists.txt`](https://github.com/microsoft/vcpkg/blob/master/ports/loguru/CMakeLists.txt) to export `loguru` as a library for use. That's why I submit this pr , in order to facilitate better use by users. 😊