### PR TITLE
Fix MINGW32 errors and warnings

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -52,6 +52,7 @@
 
 #ifdef _WIN32
 	#include <direct.h>
+	#include <share.h>
 
 	#define localtime_r(a, b) localtime_s(b, a) // No localtime_r with MSVC, but arguments are swapped for localtime_s
 #else
@@ -127,7 +128,9 @@
 		#define _WIN32_WINNT 0x0502
 	#endif
 	#define WIN32_LEAN_AND_MEAN
-	#define NOMINMAX
+	#ifndef NOMINMAX
+		#define NOMINMAX
+	#endif
 	#include <windows.h>
 #endif
 
@@ -1034,7 +1037,7 @@ namespace loguru
 	// Where we store the custom thread name set by `set_thread_name`
 	char* thread_name_buffer()
 	{
-		__declspec( thread ) static char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
+		thread_local static char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
 		return &thread_name[0];
 	}
 #endif // LOGURU_WINTHREADS


### PR DESCRIPTION
* Include `share.h` for `_SH_DENYNO`’s definition
* Define `NOMINMAX` only if not already defined; MINGW warns of redefinition since `bits/os_defines.h` included by `<algorithm>` already defines it
* Use C++11 `thread_local` instead of the non-standard option of `__declspec(thread)` [1]

[1]: https://learn.microsoft.com/en-us/cpp/cpp/thread?view=msvc-170