### PR TITLE
Fixed compilation errors during macro expansion by vs2022

### DIFF
--- a/loguru.hpp
+++ b/loguru.hpp
@@ -1139,8 +1139,8 @@ LOGURU_ANONYMOUS_NAMESPACE_END
 	// Debug logging enabled:
 	#define DLOG_F(verbosity_name, ...)     LOG_F(verbosity_name, __VA_ARGS__)
 	#define DVLOG_F(verbosity, ...)         VLOG_F(verbosity, __VA_ARGS__)
-	#define DLOG_IF_F(verbosity_name, ...)  LOG_IF_F(verbosity_name, __VA_ARGS__)
-	#define DVLOG_IF_F(verbosity, ...)      VLOG_IF_F(verbosity, __VA_ARGS__)
+	#define DLOG_IF_F(verbosity_name, cond, ...)  LOG_IF_F(verbosity_name, cond, __VA_ARGS__)
+	#define DVLOG_IF_F(verbosity, cond, ...)      VLOG_IF_F(verbosity, cond, __VA_ARGS__)
 	#define DRAW_LOG_F(verbosity_name, ...) RAW_LOG_F(verbosity_name, __VA_ARGS__)
 	#define DRAW_VLOG_F(verbosity, ...)     RAW_VLOG_F(verbosity, __VA_ARGS__)
 #else


### PR DESCRIPTION
On Visual Studio 2022 compiler, the macro expansion of DLOG_IF_F fails for some reasons. __VA_ARGS__ is expanded into 'cond' variable of the VLOG_IF macro and : loguru::log() only got three arguments.

#define VLOG_IF_F(verbosity, cond, ...)                                                            \
	((verbosity) > loguru::current_verbosity_cutoff() || (cond) == false)                          \
		? (void)0                                                                                  \
		: loguru::log(verbosity, __FILE__, __LINE__, __VA_ARGS__) 
		
I have added 'cond' parameter to DLOG_IF_F and DVLOG_IF_F so the signature maps correctly with VLOG_IF_F and it fixes the problem.