### PR TITLE
Fix invalid regex in lnav_format_loguru_cpp.json

### DIFF
--- a/lnav_format_loguru_cpp.json
+++ b/lnav_format_loguru_cpp.json
@@ -5,7 +5,7 @@
         "url": "",
         "regex": {
             "main" : {
-                "pattern": "^(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) \\((?<uptime>.*)s\\) \\[(?<thread>.*)\\]\\s+(?<class>\\S+):(?<line>\\w+)\\s+(?<level>\\w+)\\| (?<bod$
+                "pattern": "^(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) \\((?<uptime>.*)s\\) \\[(?<thread>.*)\\]\\s+(?<class>\\S+):(?<line>\\w+)\\s+(?<level>\\w+)\\| (?<body>.*)$"
             }
         },
         "level-field": "level",

--- a/lnav_format_loguru_cpp.json
+++ b/lnav_format_loguru_cpp.json
@@ -5,7 +5,7 @@
         "url": "",
         "regex": {
             "main" : {
-                "pattern": "^(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) \\((?<uptime>.*)s\\) \\[(?<thread>.*)\\]\\s+(?<class>\\S+):(?<line>\\w+)\\s+(?<level>\\w+)\\| (?<body>.*)$"
+                "pattern": "^(?<timestamp>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}) \\((?<uptime>.*)s\\) \\[(?<thread>.*)\\]\\s*(?<class>\\S+):(?<line>\\w+)\\s+(?<level>\\w+)\\| (?<body>.*)$"
             }
         },
         "level-field": "level",


### PR DESCRIPTION
Verified that the corrected file is valid (at least, valid enough for lnav to use it without erroring out). Here's a screenshot with the highlighting:
![image](https://github.com/emilk/loguru/assets/70862148/69407c9f-29eb-4fba-b892-ac400354a708)
