### PR TITLE
Replace _fsopen on Windows to allow the opened file to be used by logrotate (supporting move and delete operations)

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -618,6 +618,7 @@ namespace loguru
 	{
 		VLOG_F(g_internal_verbosity, "atexit");
 		flush();
+        remove_all_callbacks();
 	}
 
 	static void install_signal_handlers(const SignalOptions& signal_options);


### PR DESCRIPTION
When using loguru on Windows with` #define LOGURU_WITH_FILEABS 1`, `logrotate` cannot be used to manage the growing file size. This is because files opened with _fsopen cannot be used by logrotate while the process is still running. I made some modifications to solve this issue and conducted some tests.