### PR TITLE
Enable LOGURU_STACKTRACES cmake variable by default on non-windows platforms using glibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,36 @@ endif()
 # --- determine if linking 'dl' is required
 # ----------------------------------------------------------
 
+# loguru.cpp implicitly enables stacktraces on non-windows systems w/ glibc
+# so the following checks are needed to establish the CMake vars default value
+if((NOT DEFINED LOGURU_STACKTRACES) AND (NOT WIN32 AND NOT CYGWIN))
+  message(STATUS "checking for glibc")
+  # Create temp file for testing if the current compiler uses glibc
+  file(WRITE "${PROJECT_BINARY_DIR}/test_for_glibc.cpp" [[
+    #include <cstdio>
+    #define RESULT 1
+    #ifdef __GLIBC__
+      #define RESULT 0
+    #endif
+    int main() { return RESULT; }
+  ]])
+  # Attempt to compile and run the glibc tester program
+  try_run(_try_run_result _try_run_compile_result
+    ${PROJECT_BINARY_DIR}
+    ${PROJECT_BINARY_DIR}/test_for_glibc.cpp
+  )
+  if (_try_run_result EQUAL 0)
+    message(STATUS "checking for glibc - found")
+    message(STATUS
+      "glibc was found on a non-Windows system, LOGURU_STACKTRACES will be "
+      "enabled by default. "
+      "Set -DLOGURU_STACKTRACES=FALSE to explicitly disable stacktraces")
+    set(LOGURU_STACKTRACES 1)
+  else()
+    message(STATUS "checking for glibc - not found")
+  endif()
+endif()
+
 if (LOGURU_STACKTRACES AND (NOT CMAKE_DL_LIBS))
   message(WARNING
     "Stack traces requested but the required 'dl' library was not found. "


### PR DESCRIPTION
Changes:
- Fixes issue [#248](https://github.com/emilk/loguru/issues/248)
- CMake now performs a quick `try_run()` to inspect whether the currently detected C++ compiler is using glibc, and if so sets the LOGURU_STACKTRACES variable to TRUE by default to match the default value of the LOGURU_STACKTRACES macro inside `loguru.cpp`.

Notes:
- This is required because the cmake file is currently setup to only link loguru to the `dl` library if the cmake variable LOGURU_STACKTRACES is TRUE. Unfortunately, the `loguru.cpp` file implicitly enables the stacktraces feature under certain conditions (glibc on non-windows) and the CMake file wasn't previously written to account for that. This meant that the `dl` library wasn't being linked even though stacktraces were enabled (in the .cpp file), causing a linking error.
  - `undefined reference to 'dladdr'`