### PR TITLE
loguru: use `iscntrl` to test for control characters

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -568,7 +568,7 @@ namespace loguru
 			else if (c == '\'') { out += "\\\'"; }
 			else if (c == '\"') { out += "\\\""; }
 			else if (c == ' ')  { out += "\\ ";  }
-			else if (0 <= c && c < 0x20) { // ASCI control character:
+			else if (std::iscntrl(c)) { // ASCII control character:
 			// else if (c < 0x20 || c != (c & 127)) { // ASCII control character or UTF-8:
 				out += "\\x";
 				write_hex_byte(out, static_cast<uint8_t>(c));
@@ -1842,7 +1842,7 @@ namespace loguru
 		else if (c == '\n') { str += "\\n";  }
 		else if (c == '\r') { str += "\\r";  }
 		else if (c == '\t') { str += "\\t";  }
-		else if (0 <= c && c < 0x20) {
+		else if (std::iscntrl(c)) {
 			str += "\\u";
 			write_hex_16(static_cast<uint16_t>(c));
 		} else { str += c; }


### PR DESCRIPTION
This avoids warnings on aarch64 where `char` is unsigned. It is also more explicit about what it is testing for.