### PR TITLE
Update all cmake_minimum_required to 3.12; support CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 # --- include useful utility functions
 # ----------------------------------------------------------

--- a/glog_bench/CMakeLists.txt
+++ b/glog_bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 project(glog_bench)
 

--- a/glog_example/CMakeLists.txt
+++ b/glog_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 project(glog_example)
 

--- a/loguru_bench/CMakeLists.txt
+++ b/loguru_bench/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 project(loguru_bench)
 

--- a/loguru_cmake_example/CMakeLists.txt
+++ b/loguru_cmake_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.12)
 
 project(loguru_cmake_example CXX)
 

--- a/loguru_example/CMakeLists.txt
+++ b/loguru_example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 project(loguru_example)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 project(loguru_test)
 

--- a/test/fail_test_wrapper.cmake
+++ b/test/fail_test_wrapper.cmake
@@ -1,5 +1,5 @@
 #!/usr/bin/env cmake -P
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.12)
 
 get_filename_component(CurrentFile ${CMAKE_CURRENT_LIST_FILE} NAME)
 


### PR DESCRIPTION
CMake 4.0 drops support for CMake <3.5, so minimum versions need to be adjusted for forward compatibility. As long as we are touching minimum versions, let’s harmonize them all at 3.12, which can be considered the oldest “modern” CMake release, and which is available in all known supported Linux distributions today.

I tested this (as best I could) with CMake 4.0.0rc2.