### PR TITLE
Fix for Darwin when pthread_threadid_np is unavailable

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -71,7 +71,8 @@
 #endif
 
 #ifdef __APPLE__
-	#include "TargetConditionals.h"
+	#include <AvailabilityMacros.h>
+	#include <TargetConditionals.h>
 #endif
 
 // TODO: use defined(_POSIX_VERSION) for some of these things?
@@ -1096,7 +1097,11 @@ namespace loguru
 
 			#ifdef __APPLE__
 				uint64_t thread_id;
-				pthread_threadid_np(pthread_self(), &thread_id);
+				#if MAC_OS_X_VERSION_MAX_ALLOWED < 1060 || defined(__POWERPC__)
+					thread_id = pthread_mach_thread_np(pthread_self());
+				#else
+					pthread_threadid_np(pthread_self(), &thread_id);
+				#endif
 			#elif defined(__FreeBSD__)
 				long thread_id;
 				(void)thr_self(&thread_id);


### PR DESCRIPTION
`pthread_threadid_np` does not exist before 10.6 and is not available in 10.6 for powerpc. Provide a fallback for it.