### PR TITLE
eliminate compilation warnings

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1034,7 +1034,7 @@ namespace loguru
 	// Where we store the custom thread name set by `set_thread_name`
 	char* thread_name_buffer()
 	{
-		__declspec( thread ) static char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
+		static thread_local char thread_name[LOGURU_THREADNAME_WIDTH + 1] = {0};
 		return &thread_name[0];
 	}
 #endif // LOGURU_WINTHREADS


### PR DESCRIPTION
Replace the specific syntax of MSVC with thread_local of standard C++11 to eliminate compilation warnings