### PR TITLE
fix: include share.h for Windows compilation

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -52,6 +52,7 @@
 
 #ifdef _WIN32
 	#include <direct.h>
+	#include <share.h>
 
 	#define localtime_r(a, b) localtime_s(b, a) // No localtime_r with MSVC, but arguments are swapped for localtime_s
 #else


### PR DESCRIPTION
Includes `<share.h>` to resolve Windows compilation failures related to file sharing flags (e.g., `_SH_DENYNO` with `_fsopen`).