### PR TITLE
Fix -Wtype-limits warning where char is unsigned

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -575,7 +575,7 @@ namespace loguru
 			else if (c == '\'') { out += "\\\'"; }
 			else if (c == '\"') { out += "\\\""; }
 			else if (c == ' ')  { out += "\\ ";  }
-			else if (0 <= c && c < 0x20) { // ASCI control character:
+			else if (static_cast<unsigned char>(c) < 0x20) { // ASCII control character:
 			// else if (c < 0x20 || c != (c & 127)) { // ASCII control character or UTF-8:
 				out += "\\x";
 				write_hex_byte(out, static_cast<uint8_t>(c));
@@ -1860,7 +1860,7 @@ namespace loguru
 		else if (c == '\n') { str += "\\n";  }
 		else if (c == '\r') { str += "\\r";  }
 		else if (c == '\t') { str += "\\t";  }
-		else if (0 <= c && c < 0x20) {
+		else if (static_cast<unsigned char>(c) < 0x20) {
 			str += "\\u";
 			write_hex_16(static_cast<uint16_t>(c));
 		} else { str += c; }


### PR DESCRIPTION
`0 <= c && c < 0x20` triggers `-Wtype-limits` (and fails `-Werror` builds) on ARM/AArch64 where `char` is unsigned. Cast to `unsigned char` instead. Same behavior on all platforms, and no `std::iscntrl` UB for negative chars.

Supersedes:
- #256
- #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)