### PR TITLE
Add DLOG_SCOPE_F, DVLOG_SCOPE_F, and DLOG_SCOPE_FUNCTION

### DIFF
--- a/loguru.hpp
+++ b/loguru.hpp
@@ -1143,6 +1143,9 @@ LOGURU_ANONYMOUS_NAMESPACE_END
 	#define DVLOG_IF_F(verbosity, cond, ...)      VLOG_IF_F(verbosity, cond, __VA_ARGS__)
 	#define DRAW_LOG_F(verbosity_name, ...) RAW_LOG_F(verbosity_name, __VA_ARGS__)
 	#define DRAW_VLOG_F(verbosity, ...)     RAW_VLOG_F(verbosity, __VA_ARGS__)
+	#define DVLOG_SCOPE_F(verbosity, ...)   VLOG_SCOPE_F(verbosity, __VA_ARGS__)
+	#define DLOG_SCOPE_F(verbosity_name, ...) LOG_SCOPE_F(verbosity_name, __VA_ARGS__)
+	#define DLOG_SCOPE_FUNCTION(verbosity_name) LOG_SCOPE_FUNCTION(verbosity_name)
 #else
 	// Debug logging disabled:
 	#define DLOG_F(verbosity_name, ...)
@@ -1151,6 +1154,9 @@ LOGURU_ANONYMOUS_NAMESPACE_END
 	#define DVLOG_IF_F(verbosity, ...)
 	#define DRAW_LOG_F(verbosity_name, ...)
 	#define DRAW_VLOG_F(verbosity, ...)
+	#define DVLOG_SCOPE_F(verbosity, ...)
+	#define DLOG_SCOPE_F(verbosity_name, ...)
+	#define DLOG_SCOPE_FUNCTION(verbosity_name)
 #endif
 
 #define CHECK_EQ_F(a, b, ...) CHECK_OP_F(a, b, ==, ##__VA_ARGS__)


### PR DESCRIPTION
Debug-only variants of the scope macros, matching the existing `DLOG_F` family. Compiled out when `LOGURU_DEBUG_LOGGING` is 0.

Supersedes:
- #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)