### PR TITLE
Static analyzer fixes

### DIFF
--- a/loguru.cpp
+++ b/loguru.cpp
@@ -1944,7 +1944,7 @@ namespace loguru
 		memset(&sig_action, 0, sizeof(sig_action));
 		sigemptyset(&sig_action.sa_mask);
 		sig_action.sa_handler = SIG_DFL;
-		sigaction(signal_number, &sig_action, NULL);
+		(void)sigaction(signal_number, &sig_action, NULL); // Restoring the default handler; failure is not actionable here.
 		kill(getpid(), signal_number);
 	}
 

--- a/loguru.cpp
+++ b/loguru.cpp
@@ -768,6 +768,7 @@ namespace loguru
 	{
 		CHECK_F(file_path_const && *file_path_const);
 		char* file_path = STRDUP(file_path_const);
+		CHECK_NOTNULL_F(file_path, "Failed to allocate memory");
 		for (char* p = strchr(file_path + 1, '/'); p; p = strchr(p + 1, '/')) {
 			*p = '\0';
 
@@ -1894,6 +1895,7 @@ namespace loguru
 		Text parent_ec = get_error_context_for(ec_handle);
 		size_t buffer_size = strlen(parent_ec.c_str()) + 2;
 		char* with_newline = reinterpret_cast<char*>(malloc(buffer_size));
+		CHECK_NOTNULL_F(with_newline, "Failed to allocate memory");
 		with_newline[0] = '\n';
 	#ifdef _WIN32
 		strncpy_s(with_newline + 1, buffer_size, parent_ec.c_str(), buffer_size - 2);

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -696,12 +696,12 @@ namespace loguru
 		LogScopeRAII& operator=(const LogScopeRAII&) = delete;
 		void operator=(LogScopeRAII&&) = delete;
 
-		Verbosity   _verbosity;
-		const char* _file; // Set to null if we are disabled due to verbosity
-		unsigned    _line;
-		bool        _indent_stderr; // Did we?
-		long long   _start_time_ns;
-		char        _name[LOGURU_SCOPE_TEXT_SIZE];
+		Verbosity   _verbosity = Verbosity_INVALID;
+		const char* _file = nullptr; // Set to null if we are disabled due to verbosity
+		unsigned    _line = 0;
+		bool        _indent_stderr = false; // Did we?
+		long long   _start_time_ns = 0;
+		char        _name[LOGURU_SCOPE_TEXT_SIZE] = {};
 	};
 
 	// Marked as 'noreturn' for the benefit of the static analyzer and optimizer.
@@ -865,7 +865,7 @@ namespace loguru
 		const char*  _file;
 		unsigned     _line;
 		const char*  _descr;
-		EcEntryBase* _previous;
+		EcEntryBase* _previous = nullptr;
 	};
 
 	template<typename T>

--- a/loguru.hpp
+++ b/loguru.hpp
@@ -851,7 +851,7 @@ namespace loguru
 	{
 	public:
 		EcEntryBase(const char* file, unsigned line, const char* descr);
-		~EcEntryBase();
+		virtual ~EcEntryBase();
 		EcEntryBase(const EcEntryBase&) = delete;
 		EcEntryBase(EcEntryBase&&) = delete;
 		EcEntryBase& operator=(const EcEntryBase&) = delete;


### PR DESCRIPTION
The uncontroversial parts of #179, rebased on current master:

- Initialize all members of `LogScopeRAII` and `EcEntryBase`
- Make `EcEntryBase` destructor virtual (class has a pure virtual method)
- Explicitly ignore `sigaction` return value in the signal handler
- Check for allocation failure before dereferencing `STRDUP`/`malloc` results

Left out of #179: dropping `__declspec(thread)` (would make the Windows thread name buffer shared across threads) and removing the `symbols[i]` fallback in the stack trace.

Related:
- #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)